### PR TITLE
feat: create a script to install and run arweave node

### DIFF
--- a/scripts/install_arweave.sh
+++ b/scripts/install_arweave.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+apt install -y git curl build-essential cmake pkg-config libssl-dev libsqlite3-dev libgmp-dev libncurses-dev ncurses-bin
+
+rm -r ~/compilation
+mkdir -p ~/compilation/
+
+cd ~/compilation
+
+git clone --depth=1 -b maint-24 https://github.com/erlang/otp
+cd ~/compilation/otp
+./configure
+make
+make install
+
+
+cd ~/compilation
+git clone -b N.2.5.1.0 --recursive https://github.com/ArweaveTeam/arweave.git
+cd ~/compilation/arweave
+./rebar3 as prod tar
+
+
+mkdir -p ~/Applications/arweave
+cp ~/compilation/arweave/_build/prod/rel/arweave/arweave-2.5.1.0.tar.gz ~/Applications/arweave/
+cd ~/Applications/arweave
+tar -xzvf arweave-2.5.1.0.tar.gz
+
+echo -n "fs.file-max=100000000" >> /etc/sysctl.conf
+sysctl -p
+echo -n "DefaultLimitNOFILE=10000000" >> /etc/systemd/user.conf
+echo -n "DefaultLimitNOFILE=10000000" >> /etc/systemd/system.conf

--- a/scripts/run_arweave.sh
+++ b/scripts/run_arweave.sh
@@ -1,0 +1,10 @@
+~/Applications/arweave/bin/start mine \
+ mining_addr nKn0ZQET1VcpW6_OdpVOP-Pm6b-_BwagHTg3BtByVkA \
+ peer 188.166.200.45 \
+ peer 188.166.192.169 \
+ peer 163.47.11.64 \
+ peer 139.59.51.59 \
+ peer 138.197.232.192 \
+ peer 178.62.222.154 \
+ peer 51.75.206.225 \
+ peer 90.70.52.14


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- This is a script that will run arweave node on the cloud instance.
- This is necessary at the moment, since running arweave in Dockerfile has trouble connecting to the default port.
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```

```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- The install script is not fail safe, meaning it has to be run in the host only once since it is appending configurations into the system files.
- using Dockerfile image has trouble connecting to the default port.